### PR TITLE
feat: return circled

### DIFF
--- a/packages/snfoundry/contracts/src/components/MarquisGame.cairo
+++ b/packages/snfoundry/contracts/src/components/MarquisGame.cairo
@@ -15,6 +15,7 @@ pub mod MarquisGame {
     use core::traits::Into;
     use keccak::keccak_u256s_le_inputs;
     use openzeppelin::access::ownable::OwnableComponent::InternalTrait as OwnableInternalTrait;
+    use openzeppelin::access::ownable::OwnableComponent::Ownable as OwnableTrait;
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::token::erc20::interface::{IERC20CamelDispatcher, IERC20CamelDispatcherTrait};
     use starknet::eth_signature::{verify_eth_signature, public_key_point_to_eth_address};
@@ -180,10 +181,19 @@ pub mod MarquisGame {
         /// @param session_id The ID of the session
         /// @param player The address of the player
         fn _require_next_player_in_session(
-            ref self: ComponentState<TContractState>, session_id: u256, player: ContractAddress
+            ref self: ComponentState<TContractState>,
+            session_id: u256,
+            player: ContractAddress,
+            is_owner: bool
         ) {
             let _session_next_player_id = self._session_next_player_id(session_id);
-            let session_player = self.session_players.read((session_id, _session_next_player_id));
+            let mut ownable_component = get_dep_component_mut!(ref self, Ownable);
+
+            let session_player = match is_owner {
+                true => ownable_component.owner(),
+                false => self.session_players.read((session_id, _session_next_player_id))
+            };
+
             assert(session_player == player, GameErrors::NOT_PLAYER_TURN);
         }
 
@@ -242,15 +252,22 @@ pub mod MarquisGame {
         fn _before_play(
             ref self: ComponentState<TContractState>,
             session_id: u256,
-            mut verifiableRandomNumberArray: Array<VerifiableRandomNumber>
+            mut verifiableRandomNumberArray: Array<VerifiableRandomNumber>,
+            is_owner: bool
         ) -> (Session, Array<u256>) {
             // read the session
             let mut session: Session = self.sessions.read(session_id);
-            let player = get_caller_address();
+            let mut ownable_component = get_dep_component_mut!(ref self, Ownable);
+
+            let player = match is_owner {
+                true => ownable_component.owner(),
+                false => get_caller_address()
+            };
+
             // pre checks
             self._require_initialized();
             self._require_session_playing(session.id);
-            self._require_next_player_in_session(session.id, player);
+            self._require_next_player_in_session(session.id, player, is_owner);
             // update session play_count
             session.nonce += 1;
             let player_as_felt252: felt252 = get_caller_address().into();
@@ -276,7 +293,8 @@ pub mod MarquisGame {
                     session.id, session.nonce, _random_number, player_as_u256, this_contract_as_u256
                 ];
                 let message_hash = keccak_u256s_le_inputs(u256_inputs.span());
-                // let signature = format!("{}-{}-{}-{}-{}", _random_number, _v, _r, _s, message_hash);
+                // let signature = format!("{}-{}-{}-{}-{}", _random_number, _v, _r, _s,
+                // message_hash);
                 verify_eth_signature(
                     message_hash, signature_from_vrs(_v, _r, _s), self.marquis_oracle_address.read()
                 );

--- a/packages/snfoundry/contracts/src/games/Ludo.cairo
+++ b/packages/snfoundry/contracts/src/games/Ludo.cairo
@@ -137,6 +137,12 @@ mod Ludo {
                             self.winning_tokens.read((session_id, 0, 2)),
                             self.winning_tokens.read((session_id, 0, 3))
                         ),
+                        player_tokens_circled: (
+                            self.token_circled.read((session_id, 0, 0)),
+                            self.token_circled.read((session_id, 0, 1)),
+                            self.token_circled.read((session_id, 0, 2)),
+                            self.token_circled.read((session_id, 0, 3))
+                        ),
                     },
                     SessionUserStatus {
                         player_id: 1,
@@ -151,6 +157,12 @@ mod Ludo {
                             self.winning_tokens.read((session_id, 1, 1)),
                             self.winning_tokens.read((session_id, 1, 2)),
                             self.winning_tokens.read((session_id, 1, 3))
+                        ),
+                        player_tokens_circled: (
+                            self.token_circled.read((session_id, 1, 0)),
+                            self.token_circled.read((session_id, 1, 1)),
+                            self.token_circled.read((session_id, 1, 2)),
+                            self.token_circled.read((session_id, 1, 3))
                         ),
                     },
                     SessionUserStatus {
@@ -167,6 +179,12 @@ mod Ludo {
                             self.winning_tokens.read((session_id, 2, 2)),
                             self.winning_tokens.read((session_id, 2, 3))
                         ),
+                        player_tokens_circled: (
+                            self.token_circled.read((session_id, 2, 0)),
+                            self.token_circled.read((session_id, 2, 1)),
+                            self.token_circled.read((session_id, 2, 2)),
+                            self.token_circled.read((session_id, 2, 3))
+                        ),
                     },
                     SessionUserStatus {
                         player_id: 3,
@@ -181,6 +199,12 @@ mod Ludo {
                             self.winning_tokens.read((session_id, 3, 1)),
                             self.winning_tokens.read((session_id, 3, 2)),
                             self.winning_tokens.read((session_id, 3, 3))
+                        ),
+                        player_tokens_circled: (
+                            self.token_circled.read((session_id, 3, 0)),
+                            self.token_circled.read((session_id, 3, 1)),
+                            self.token_circled.read((session_id, 3, 2)),
+                            self.token_circled.read((session_id, 3, 3))
                         ),
                     }
                 )
@@ -290,9 +314,11 @@ mod Ludo {
             let has_circled = self.token_circled.read((session_id, player_id, token_id));
 
             if current_position > exit_position && (player_id == 0 || has_circled) {
+                // current_position = 12, exit_position = 11
+                // remaining_steps = 1
                 let remaining_steps = current_position - exit_position;
                 if remaining_steps <= 6 {
-                    if current_position == exit_position + 6 {
+                    if current_position == exit_position + 7 {
                         // Mark the token as a winning token
                         self.winning_tokens.write((session_id, player_id, token_id), true);
                         let winning_token_count = self

--- a/packages/snfoundry/contracts/src/interfaces/ILudo.cairo
+++ b/packages/snfoundry/contracts/src/interfaces/ILudo.cairo
@@ -59,6 +59,14 @@ pub trait ILudo<ContractState> {
         ludo_move: LudoMove,
         verifiableRandomNumberArray: Array<VerifiableRandomNumber>
     );
+
+    fn owner_play(
+        ref self: ContractState,
+        session_id: u256,
+        ludo_move: LudoMove,
+        verifiableRandomNumberArray: Array<VerifiableRandomNumber>
+    );
+
     fn get_session_status(
         self: @ContractState, session_id: u256
     ) -> (SessionData, LudoSessionStatus);

--- a/packages/snfoundry/contracts/src/interfaces/ILudo.cairo
+++ b/packages/snfoundry/contracts/src/interfaces/ILudo.cairo
@@ -38,6 +38,7 @@ pub struct SessionUserStatus {
     pub player_id: u32,
     pub player_tokens_position: (u256, u256, u256, u256),
     pub player_winning_tokens: (bool, bool, bool, bool),
+    pub player_tokens_circled: (bool, bool, bool, bool),
 }
 
 #[derive(Drop, Serde, starknet::Store)]


### PR DESCRIPTION
# Return has circled data from contract

## Types of change

- [x] Return has circled data from contract `get_session_status`
- [x] Fix the destination condition checking bug, where changed from `current_position == exit_position + 6` to `current_position == exit_position + 7`
